### PR TITLE
feat(button): add a rewrite button for each AI generator history item

### DIFF
--- a/src/renderer/components/ai/AIGeneratorComponent.vue
+++ b/src/renderer/components/ai/AIGeneratorComponent.vue
@@ -175,8 +175,14 @@
                             </n-thing>
 
                             <template #suffix>
-                                <n-space v-if="item.status === 'success'">
-                                    <n-button size="small" @click="copyHistoryItem(item)">复制</n-button>
+                               <n-space vertical>
+                                    <n-space v-if="item.status === 'success'">
+                                        <n-button size="small" @click="copyHistoryItem(item)">复制</n-button>
+
+                                        <n-button size="small" @click="rewriteRequirement(item)" >
+                                            重写
+                                        </n-button>
+                                    </n-space>
                                 </n-space>
                             </template>
                         </n-list-item>
@@ -840,6 +846,20 @@ const copyHistoryItem = async (item: AIGenerationHistory) => {
     } catch (error) {
         message.error('复制失败')
     }
+}
+//重写历史要求
+const rewriteRequirement = (item: AIGenerationHistory) => {
+    //将之前的要求写入表单
+    formData.topic = item.topic || ''
+    //清空之前生成的prompt
+    generatedResult.value = ''
+    message.success('要求已填充到输入框，请修改后重新生成')
+    setTimeout(() => {
+        const input = document.querySelector('.ai-generator .n-input textarea')
+        if (input) {
+            input.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        }
+    }, 100)
 }
 
 // 分隔动画函数


### PR DESCRIPTION
## [功能] 在AI生成页面的生成历史为每一条历史记录添加一个重写按钮

## 需求
有时候需要根据ai生成的prompt来调整生成要求，然而上游版本目前不能复制历史记录的标题，也没有重写要求功能。

### 截图
![image](https://github.com/user-attachments/assets/ccaaed13-fdf0-4e4c-b905-d5bd58a57232)

![image](https://github.com/user-attachments/assets/5f3f2f52-28e8-4205-aa9f-8da141941f9c)
