### PR TITLE
恢复 README Star History

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ AI 快速调整
 
 </div>
 
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=yarin-zhang/AI-Gist&type=Date)](https://star-history.dera.page/#yarin-zhang/AI-Gist&type=Date)
+
 ## 许可证
 
 本项目采用 [AGPL 许可证](./LICENSE)，请在使用时遵守相关条款。


### PR DESCRIPTION
当前 README 中的 Star History 图表无法正常显示，这是因为原有图表受 GitHub 限制已失效。本 PR 恢复该图表，并切换到新的数据源，使 Star 历史图能够稳定展示。

此前的移除发生在提交 8ff327c（2026-08-17-移除 README Star History）。