### PR TITLE
修复 iOS 端语言跟随系统失效与中日韩字形显示为豆腐块

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -6,6 +6,13 @@
 	<string>$(CAPACITOR_DEBUG)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>zh-Hans</string>
+		<string>zh-Hant</string>
+		<string>ja</string>
+	</array>
 	<key>CFBundleDisplayName</key>
 	<string>AI Gist</string>
 	<key>CFBundleExecutable</key>

--- a/src/renderer/assets/styles/global.css
+++ b/src/renderer/assets/styles/global.css
@@ -1,3 +1,101 @@
+/* 中日韩字形回退。
+
+   系统字体（-apple-system / system-ui）本身不含 CJK 字形。真机上 WebKit 会自动接续系统
+   字体族里的 PingFang / Hiragino，但 iOS 模拟器的运行时缺少这段接续关系，中文和日文界面
+   会整片渲染成豆腐块（□）。更麻烦的是：只要 -apple-system 排在首位，WebKit 就不再往后
+   查找同一 font-family 列表里的其它字体，所以单纯在列表末尾补一个 "PingFang SC" 无效。
+
+   因此这里用 unicode-range 把 CJK 码位单独绑到系统自带的中日字体上，并把它排在系统字体
+   之前：Latin 仍然走 -apple-system，只有 CJK 字符落到下面这些 face 上。真机、Windows、
+   Android 上 local() 要么命中同一个字体、要么整条 face 不可用并沿用原有回退，观感不变。
+
+   PingFang 在模拟器运行时里不含假名，Hiragino 不含简体专用字形，所以两者互为补充，
+   顺序按界面语言切换，避免用中文字形渲染日文。 */
+
+@font-face {
+  font-family: "AppCJK-SC";
+  font-weight: 400;
+  font-style: normal;
+  src: local("PingFangSC-Regular");
+  unicode-range: U+2E80-303F, U+3040-30FF, U+3100-312F, U+31C0-31EF, U+3200-32FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF, U+FE30-FE4F, U+FF00-FFEF, U+20000-2A6DF;
+}
+
+@font-face {
+  font-family: "AppCJK-SC";
+  font-weight: 500;
+  font-style: normal;
+  src: local("PingFangSC-Medium");
+  unicode-range: U+2E80-303F, U+3040-30FF, U+3100-312F, U+31C0-31EF, U+3200-32FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF, U+FE30-FE4F, U+FF00-FFEF, U+20000-2A6DF;
+}
+
+@font-face {
+  font-family: "AppCJK-SC";
+  font-weight: 600 900;
+  font-style: normal;
+  src: local("PingFangSC-Semibold");
+  unicode-range: U+2E80-303F, U+3040-30FF, U+3100-312F, U+31C0-31EF, U+3200-32FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF, U+FE30-FE4F, U+FF00-FFEF, U+20000-2A6DF;
+}
+
+@font-face {
+  font-family: "AppCJK-TC";
+  font-weight: 400;
+  font-style: normal;
+  src: local("PingFangTC-Regular");
+  unicode-range: U+2E80-303F, U+3040-30FF, U+3100-312F, U+31C0-31EF, U+3200-32FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF, U+FE30-FE4F, U+FF00-FFEF, U+20000-2A6DF;
+}
+
+@font-face {
+  font-family: "AppCJK-TC";
+  font-weight: 500;
+  font-style: normal;
+  src: local("PingFangTC-Medium");
+  unicode-range: U+2E80-303F, U+3040-30FF, U+3100-312F, U+31C0-31EF, U+3200-32FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF, U+FE30-FE4F, U+FF00-FFEF, U+20000-2A6DF;
+}
+
+@font-face {
+  font-family: "AppCJK-TC";
+  font-weight: 600 900;
+  font-style: normal;
+  src: local("PingFangTC-Semibold");
+  unicode-range: U+2E80-303F, U+3040-30FF, U+3100-312F, U+31C0-31EF, U+3200-32FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF, U+FE30-FE4F, U+FF00-FFEF, U+20000-2A6DF;
+}
+
+@font-face {
+  font-family: "AppCJK-JP";
+  font-weight: 400;
+  font-style: normal;
+  src: local("HiraginoSans-W3");
+  unicode-range: U+2E80-303F, U+3040-30FF, U+3100-312F, U+31C0-31EF, U+3200-32FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF, U+FE30-FE4F, U+FF00-FFEF, U+20000-2A6DF;
+}
+
+@font-face {
+  font-family: "AppCJK-JP";
+  font-weight: 500;
+  font-style: normal;
+  src: local("HiraginoSans-W5");
+  unicode-range: U+2E80-303F, U+3040-30FF, U+3100-312F, U+31C0-31EF, U+3200-32FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF, U+FE30-FE4F, U+FF00-FFEF, U+20000-2A6DF;
+}
+
+@font-face {
+  font-family: "AppCJK-JP";
+  font-weight: 600 900;
+  font-style: normal;
+  src: local("HiraginoSans-W6");
+  unicode-range: U+2E80-303F, U+3040-30FF, U+3100-312F, U+31C0-31EF, U+3200-32FF, U+3400-4DBF, U+4E00-9FFF, U+F900-FAFF, U+FE30-FE4F, U+FF00-FFEF, U+20000-2A6DF;
+}
+
+:root {
+  --font-cjk-fallback: "AppCJK-SC", "AppCJK-JP";
+}
+
+html:lang(zh-Hant) {
+  --font-cjk-fallback: "AppCJK-TC", "AppCJK-JP";
+}
+
+html:lang(ja) {
+  --font-cjk-fallback: "AppCJK-JP", "AppCJK-SC";
+}
+
 /* 根元素样式 - 确保在拖拽时不显示白色背景 */
 html {
   height: 100%;
@@ -18,7 +116,7 @@ body {
   height: 100%;
   margin: 0;
   padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--font-cjk-fallback), -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: var(--font-size-base, 14px);
   -webkit-user-select: none;
   -moz-user-select: none;

--- a/src/renderer/assets/styles/loading.css
+++ b/src/renderer/assets/styles/loading.css
@@ -34,7 +34,7 @@
 #initial-loading .loading-app-name {
   font-size: 22px;
   font-weight: 600;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--font-cjk-fallback, "AppCJK-SC"), -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   letter-spacing: 0.5px;
   margin-bottom: 48px;
 }

--- a/src/renderer/assets/styles/mobile.css
+++ b/src/renderer/assets/styles/mobile.css
@@ -11,7 +11,7 @@ html.ai-gist-mobile {
   --ion-tab-bar-background: var(--surface-primary);
   --ion-item-background: var(--surface-primary);
   --ion-card-background: var(--surface-primary);
-  --ion-font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, sans-serif;
+  --ion-font-family: var(--font-cjk-fallback), -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, sans-serif;
 }
 
 body.ai-gist-mobile {

--- a/src/renderer/composables/useI18n.ts
+++ b/src/renderer/composables/useI18n.ts
@@ -1,10 +1,11 @@
 import { useI18n as useVueI18n } from 'vue-i18n'
-import { ref } from 'vue'
+import { computed } from 'vue'
 import type { SupportedLocale } from '@shared/types/preferences'
+import { applyDocumentLocale, persistUserLocale, resolveInitialLocale } from '~/i18n/locale-detection'
 
 export function useI18n() {
   const { t, locale } = useVueI18n()
-  
+
   // 支持的语言列表
   const supportedLocales = [
     { code: 'zh-CN' as const, name: '简体中文' },
@@ -12,53 +13,27 @@ export function useI18n() {
     { code: 'en-US' as const, name: 'English' },
     { code: 'ja-JP' as const, name: '日本語' }
   ]
-  
-  // 当前语言
-  const currentLocale = ref(locale.value)
-  
-  // 切换语言
+
+  // 切换语言（用户显式选择，写入本地存储）
   const switchLocale = (newLocale: SupportedLocale) => {
-    console.log('[useI18n] switchLocale 调用:', {
-      from: locale.value,
-      to: newLocale
-    })
-
     locale.value = newLocale
-    currentLocale.value = newLocale
-
-    // 保存到本地存储
-    localStorage.setItem('locale', newLocale)
-
-    console.log('[useI18n] 语言切换完成:', {
-      locale: locale.value,
-      currentLocale: currentLocale.value,
-      saved: localStorage.getItem('locale')
-    })
+    applyDocumentLocale(newLocale)
+    persistUserLocale(newLocale)
   }
-  
-  // 初始化语言设置
+
+  // 当前语言：直接跟随全局 locale，避免多个组件各自持有过期副本
+  const currentLocale = computed<SupportedLocale>({
+    get: () => locale.value as SupportedLocale,
+    set: switchLocale
+  })
+
+  // 初始化语言设置：用户选择优先，否则跟随系统语言，探测结果不落盘
   const initLocale = () => {
-    const savedLocale = localStorage.getItem('locale')
-    if (savedLocale && ['zh-CN', 'zh-TW', 'en-US', 'ja-JP'].includes(savedLocale)) {
-      switchLocale(savedLocale as SupportedLocale)
-    } else {
-      // 如果没有保存的语言设置，使用系统语言或默认语言
-      const systemLocale = navigator.language
-      if (systemLocale.startsWith('zh')) {
-        // 根据系统语言判断是简体还是繁体
-        if (systemLocale.includes('TW') || systemLocale.includes('HK')) {
-          switchLocale('zh-TW')
-        } else {
-          switchLocale('zh-CN')
-        }
-      } else if (systemLocale.startsWith('ja')) {
-        switchLocale('ja-JP')
-      } else {
-        switchLocale('en-US')
-      }
-    }
+    const resolved = resolveInitialLocale()
+    locale.value = resolved
+    applyDocumentLocale(resolved)
   }
-  
+
   return {
     t,
     locale,
@@ -67,4 +42,4 @@ export function useI18n() {
     switchLocale,
     initLocale
   }
-} 
+}

--- a/src/renderer/i18n/locale-detection.ts
+++ b/src/renderer/i18n/locale-detection.ts
@@ -1,0 +1,83 @@
+import type { SupportedLocale } from '@shared/types/preferences'
+
+export const SUPPORTED_LOCALES = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP'] as const
+
+export const LOCALE_STORAGE_KEY = 'locale'
+/** 标记 locale 是用户显式选择的，而不是自动探测的结果 */
+export const LOCALE_SOURCE_STORAGE_KEY = 'locale-source'
+
+/** 判定为繁体中文的子标签 */
+const TRADITIONAL_CHINESE_SUBTAGS = ['hant', 'tw', 'hk', 'mo']
+
+export function isSupportedLocale(value: unknown): value is SupportedLocale {
+  return typeof value === 'string' && (SUPPORTED_LOCALES as readonly string[]).includes(value)
+}
+
+/**
+ * 把 BCP 47 语言标签（zh-Hans-CN、zh-Hant-TW、ja、en-GB…）映射到应用支持的语言。
+ * 不认识的语言返回 null，由调用方继续尝试下一个候选。
+ */
+function matchLocale(tag: string): SupportedLocale | null {
+  const subtags = tag.toLowerCase().split(/[-_]/)
+  const language = subtags[0]
+
+  if (language === 'zh') {
+    // zh-Hant / zh-TW / zh-HK / zh-MO 以及 zh-Hant-HK 这类组合都算繁体
+    return subtags.slice(1).some(subtag => TRADITIONAL_CHINESE_SUBTAGS.includes(subtag))
+      ? 'zh-TW'
+      : 'zh-CN'
+  }
+  if (language === 'ja') return 'ja-JP'
+  if (language === 'en') return 'en-US'
+  return null
+}
+
+/** 按系统语言偏好顺序探测语言，全部不支持时回退到英文 */
+export function detectPreferredLocale(): SupportedLocale {
+  const candidates = navigator.languages?.length ? navigator.languages : [navigator.language]
+
+  for (const candidate of candidates) {
+    const matched = matchLocale(candidate ?? '')
+    if (matched) return matched
+  }
+
+  return 'en-US'
+}
+
+/**
+ * 读取用户显式选择过的语言。
+ *
+ * 只认带来源标记的值：旧版本会把自动探测的结果写进同一个键，而 iOS WebView 在应用
+ * 未声明 CFBundleLocalizations 时始终上报 en-US，中文/日文系统因此被永久锁在英文界面。
+ * 没有标记的旧值一律丢弃并重新探测，用户仍可在设置里改回来。
+ */
+export function readStoredLocale(): SupportedLocale | null {
+  if (localStorage.getItem(LOCALE_SOURCE_STORAGE_KEY) !== 'user') return null
+
+  const stored = localStorage.getItem(LOCALE_STORAGE_KEY)
+  return isSupportedLocale(stored) ? stored : null
+}
+
+/** 保存用户在设置里选择的语言 */
+export function persistUserLocale(locale: SupportedLocale): void {
+  localStorage.setItem(LOCALE_STORAGE_KEY, locale)
+  localStorage.setItem(LOCALE_SOURCE_STORAGE_KEY, 'user')
+}
+
+/** 启动时确定语言：用户选择优先，否则跟随系统。自动探测结果不写入存储 */
+export function resolveInitialLocale(): SupportedLocale {
+  return readStoredLocale() ?? detectPreferredLocale()
+}
+
+/** 界面语言对应的 <html lang> 值 */
+const HTML_LANG_BY_LOCALE: Record<SupportedLocale, string> = {
+  'zh-CN': 'zh-Hans',
+  'zh-TW': 'zh-Hant',
+  'en-US': 'en',
+  'ja-JP': 'ja'
+}
+
+/** 同步 <html lang>，用于 :lang() 选择 CJK 回退字体，同时改善断行与无障碍朗读 */
+export function applyDocumentLocale(locale: SupportedLocale): void {
+  document.documentElement.lang = HTML_LANG_BY_LOCALE[locale]
+}

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -2,7 +2,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import i18n from './i18n'
 import { initDatabase, databaseService, cloudSyncService, automaticBackupService } from './lib/services'
-import type { SupportedLocale } from '@shared/types/preferences'
+import { applyDocumentLocale, resolveInitialLocale } from './i18n/locale-detection'
 import { PlatformDetector } from '@shared/platform'
 import './tailwind.css'
 import './assets/scss/index.scss'
@@ -23,34 +23,10 @@ setupMobileDebug()
 
 // 初始化语言设置
 function initLocale() {
-  const savedLocale = localStorage.getItem('locale')
-  if (savedLocale && ['zh-CN', 'zh-TW', 'en-US', 'ja-JP'].includes(savedLocale)) {
-    i18n.global.locale.value = savedLocale as SupportedLocale
-    console.log(`应用语言设置: ${savedLocale}`)
-  } else {
-    // 如果没有保存的语言设置，使用系统语言或默认语言
-    const systemLocale = navigator.language
-    if (systemLocale.startsWith('zh')) {
-      // 根据系统语言判断是简体还是繁体
-      if (systemLocale.includes('TW') || systemLocale.includes('HK')) {
-        i18n.global.locale.value = 'zh-TW'
-        localStorage.setItem('locale', 'zh-TW')
-        console.log('检测到繁体中文系统，设置语言为: zh-TW')
-      } else {
-        i18n.global.locale.value = 'zh-CN'
-        localStorage.setItem('locale', 'zh-CN')
-        console.log('检测到简体中文系统，设置语言为: zh-CN')
-      }
-    } else if (systemLocale.startsWith('ja')) {
-      i18n.global.locale.value = 'ja-JP'
-      localStorage.setItem('locale', 'ja-JP')
-      console.log('检测到日语系统，设置语言为: ja-JP')
-    } else {
-      i18n.global.locale.value = 'en-US'
-      localStorage.setItem('locale', 'en-US')
-      console.log('设置默认语言为: en-US')
-    }
-  }
+  const locale = resolveInitialLocale()
+  i18n.global.locale.value = locale
+  applyDocumentLocale(locale)
+  console.log(`应用语言设置: ${locale}`)
 }
 
 // 预设初始主题类，避免闪烁

--- a/test/settings/locale-detection.test.ts
+++ b/test/settings/locale-detection.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  applyDocumentLocale,
+  detectPreferredLocale,
+  persistUserLocale,
+  readStoredLocale,
+  resolveInitialLocale,
+} from '../../src/renderer/i18n/locale-detection'
+
+const setNavigatorLanguages = (languages: string[]) => {
+  vi.spyOn(navigator, 'languages', 'get').mockReturnValue(languages)
+  vi.spyOn(navigator, 'language', 'get').mockReturnValue(languages[0] ?? '')
+}
+
+describe('detectPreferredLocale', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('把 iOS 上报的 zh-Hans-CN 识别为简体中文', () => {
+    setNavigatorLanguages(['zh-Hans-CN'])
+    expect(detectPreferredLocale()).toBe('zh-CN')
+  })
+
+  it.each(['zh-Hant', 'zh-Hant-TW', 'zh-TW', 'zh-HK', 'zh-Hant-HK', 'zh-MO'])(
+    '把 %s 识别为繁体中文',
+    tag => {
+      setNavigatorLanguages([tag])
+      expect(detectPreferredLocale()).toBe('zh-TW')
+    }
+  )
+
+  it.each([
+    ['ja', 'ja-JP'],
+    ['ja-JP', 'ja-JP'],
+    ['en', 'en-US'],
+    ['en-GB', 'en-US'],
+  ])('把 %s 识别为 %s', (tag, expected) => {
+    setNavigatorLanguages([tag])
+    expect(detectPreferredLocale()).toBe(expected)
+  })
+
+  it('跳过不支持的语言，取偏好列表里第一个支持的语言', () => {
+    setNavigatorLanguages(['ko-KR', 'de-DE', 'ja-JP', 'en-US'])
+    expect(detectPreferredLocale()).toBe('ja-JP')
+  })
+
+  it('全部不支持时回退到英文', () => {
+    setNavigatorLanguages(['ko-KR', 'de-DE'])
+    expect(detectPreferredLocale()).toBe('en-US')
+  })
+})
+
+describe('语言持久化', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('没有用户选择时跟随系统语言，且不写入存储', () => {
+    setNavigatorLanguages(['zh-Hans-CN'])
+    expect(resolveInitialLocale()).toBe('zh-CN')
+    expect(localStorage.getItem('locale')).toBeNull()
+  })
+
+  it('用户显式选择的语言优先于系统语言', () => {
+    setNavigatorLanguages(['zh-Hans-CN'])
+    persistUserLocale('en-US')
+    expect(readStoredLocale()).toBe('en-US')
+    expect(resolveInitialLocale()).toBe('en-US')
+  })
+
+  it('忽略旧版本自动探测写下的、没有来源标记的 locale', () => {
+    // 旧版 iOS 构建里 navigator.language 恒为 en-US，会把 en-US 永久写死
+    localStorage.setItem('locale', 'en-US')
+    setNavigatorLanguages(['zh-Hans-CN'])
+    expect(readStoredLocale()).toBeNull()
+    expect(resolveInitialLocale()).toBe('zh-CN')
+  })
+
+  it('忽略存储里不受支持的语言值', () => {
+    localStorage.setItem('locale', 'ko-KR')
+    localStorage.setItem('locale-source', 'user')
+    setNavigatorLanguages(['ja-JP'])
+    expect(readStoredLocale()).toBeNull()
+    expect(resolveInitialLocale()).toBe('ja-JP')
+  })
+})
+
+describe('applyDocumentLocale', () => {
+  it.each([
+    ['zh-CN', 'zh-Hans'],
+    ['zh-TW', 'zh-Hant'],
+    ['ja-JP', 'ja'],
+    ['en-US', 'en'],
+  ] as const)('把 %s 写成 <html lang="%s">，供 :lang() 选择 CJK 字体', (locale, lang) => {
+    applyDocumentLocale(locale)
+    expect(document.documentElement.lang).toBe(lang)
+  })
+})


### PR DESCRIPTION
## 背景

iOS 端应用无论系统语言是什么都显示英文；把语言修好之后，模拟器里的中文/日文界面又整片渲染成豆腐块（□）。排查后确认是两个互相独立的问题，其中第一个会实际影响线上用户。

## 问题一：应用未声明本地化语言，导致语言探测永远得到 en-US（影响线上用户）

`ios/App/App/Info.plist` 只声明了 `CFBundleDevelopmentRegion = en`，打包产物中也只有 `Base.lproj`，iOS 因此把应用视为纯英文应用 —— **WKWebView 的 `navigator.language` 无论系统语言是什么都返回 `en-US`**。

旧的初始化逻辑读到 `en-US` 后又把它写进 `localStorage`，于是英文被永久写死，即使之后修好探测也无法恢复。已从模拟器的 WebKit 存储中解码出实际持久化的值 `locale = en-US`，确认了这条链路。

> 附带说明：`ios/App/App/zh-Hans.lproj/` 虽然存在于磁盘，但没有被 Xcode 工程引用（`knownRegions = (en, Base)`），从未参与构建。

**改动**

- `ios/App/App/Info.plist` 补上 `CFBundleLocalizations`（`en` / `zh-Hans` / `zh-Hant` / `ja`）—— 这是根因修复。
- 新增 `src/renderer/i18n/locale-detection.ts`，统一 `main.ts` 与 `useI18n.ts` 中重复的探测逻辑；改为遍历 `navigator.languages` 而非只看 `navigator.language`，并修正 `zh-Hant` 被判成简体的问题（旧的 `includes('TW')` 判断会把纯 `zh-Hant` 归到 zh-CN）。
- 自动探测结果**不再写入存储**，只有用户在设置里显式选择的语言才持久化，并带上 `locale-source` 标记。

## 问题二：模拟器中 CJK 字形渲染为豆腐块（仅影响模拟器）

语言修好后界面切到中文，但所有 CJK 字符都是 `□`。用测试页定位到：

| font-family | 结果 |
|---|---|
| `"PingFang SC", sans-serif` | ✅ 正常 |
| `"Segoe UI", Roboto, "PingFang SC", sans-serif` | ✅ 正常 |
| `-apple-system, …, "PingFang SC", sans-serif` | ❌ 豆腐块 |
| `system-ui, "PingFang SC", sans-serif` | ❌ 豆腐块 |

**只要 `-apple-system` / `system-ui` 排在首位，模拟器里的 WebKit 就不再往后查找同一列表中的其它字体**，而该运行时的系统字体族里又没有 CJK 接续项（真机有，所以线上从未暴露）。同一台模拟器上原生 iOS 界面的中文显示完全正常，可见问题仅限 WebKit。

因此在字体栈末尾追加 CJK 字体是无效的。

**改动**

- `global.css` 用 `@font-face` + `unicode-range` 把 CJK 码位单独绑到系统自带的中日字体上，并排在 `-apple-system` **之前**；Latin 字符不在 unicode-range 内，仍然走 `-apple-system`。
- 字体随 `<html lang>` 切换（`applyDocumentLocale` 同步该属性），避免用中文字形渲染日文。
- 模拟器运行时里 PingFang 不含假名、Hiragino 不含简体专用字形，两者互为补充按语言排序。

真机、Windows、Android 上 `local()` 要么命中系统本就会选中的同一字体、要么整条 face 不可用并沿用原有回退，**观感不变**。

## 需要 reviewer 留意

**旧数据的迁移取舍。** 已有安装里的 `locale` 值没有来源标记，且绝大多数是错误的自动探测结果。本 PR 把无标记的值一律视为旧版遗留并重新探测。副作用是：曾在中文系统上**主动**选择英文的用户会被切回中文一次，需要重新选择。相比让所有受影响的 iOS 用户永久卡在英文，我认为这个取舍更合适，但如果你倾向保留旧值，这一处很容易改。

**PR 基线分支。** 按仓库默认分支开在 `main`，但从提交历史看功能分支通常先并入 `dev`，需要的话可直接改基线。

## 验证

- 615 条测试 + lint 全部通过，其中新增 `test/settings/locale-detection.test.ts` 共 21 条用例。
- 在 iPhone 17 Pro / iOS 26.3 模拟器（系统语言简体中文）上重新构建、安装、启动，界面完整显示中文。
- 简体 / 繁体 / 日文 / 英文 × regular / medium / bold 共 12 种组合，使用**真实构建产物中的 CSS** 逐一确认字形与标点形态正确。
- 按 `test/ui/design-system-contract.test.ts` 的约束，CSS 变量命名为 `--font-cjk-fallback`（`--app-` 前缀已废弃）。

**未覆盖：** 受本机 `xcode-select` 指向 CommandLineTools 影响，无法向模拟器注入点击，因此日文与繁体的字形验证是通过加载真实构建 CSS 的页面完成的，而非在运行中的应用内切换语言。建议合并前在应用内手动过一遍语言切换。

🤖 Generated with [Claude Code](https://claude.com/claude-code)