### PR TITLE
优化移动端标签栏高度、统一字号并修复分段控件图标居中

### DIFF
--- a/src/renderer/assets/styles/mobile.css
+++ b/src/renderer/assets/styles/mobile.css
@@ -1,9 +1,44 @@
 html.ai-gist-mobile {
-  --mobile-tabbar-height: 56px;
+  /*
+   * 底部标签栏高度 = 内容高度 + 安全区内边距。
+   * Ionic 的 ion-tab-bar 是 content-box，且自带 padding-bottom: var(--ion-safe-area-bottom)，
+   * 所以这里只能给「内容高度」，安全区通过 padding 单独补，否则会被重复计算导致标签栏过高。
+   * 安全区在原始值上收窄 10px（并保底 6px），让整条标签栏比 iOS 默认更紧凑。
+   */
+  --mobile-tabbar-content-height: 46px;
+  --mobile-tabbar-safe-inset: max(calc(env(safe-area-inset-bottom, 0px) - 10px), 6px);
+
   --mobile-page-gutter: 16px;
   --mobile-touch-target: 44px;
   --mobile-surface-border: var(--border-default);
   --mobile-elevated-shadow: var(--shadow-popover);
+
+  /*
+   * 移动端统一字号阶梯。所有移动端页面只允许使用这 6 档，禁止再写裸 px 字号，
+   * 保证跨页面的文字层级一致。
+   */
+  --mobile-font-size-caption: 11px;   /* 徽标、极小辅助信息 */
+  --mobile-font-size-footnote: 13px;  /* 次要说明、元信息、分组标题 */
+  --mobile-font-size-body: 15px;      /* 正文：列表标题、按钮、输入框 */
+  --mobile-font-size-title: 17px;     /* 导航栏标题、区块标题 */
+  --mobile-font-size-heading: 20px;   /* 详情页主标题 */
+  --mobile-font-size-display: 24px;   /* 关于页应用名等展示型标题 */
+
+  --mobile-line-height-tight: 1.25;
+  --mobile-line-height-normal: 1.45;
+  --mobile-line-height-relaxed: 1.6;
+
+  /* 统一图标尺寸 */
+  --mobile-icon-size-sm: 16px;
+  --mobile-icon-size: 20px;
+  --mobile-icon-size-lg: 24px;
+  --mobile-empty-icon-size: 56px;
+
+  /* 悬浮按钮与内容底部留白 */
+  --mobile-fab-size: 56px;
+  --mobile-fab-offset: 16px;
+  --mobile-fab-clearance: calc(var(--mobile-fab-size) + var(--mobile-fab-offset) * 2);
+
   --ion-background-color: var(--surface-body);
   --ion-text-color: var(--content-primary);
   --ion-border-color: var(--border-default);
@@ -17,6 +52,7 @@ html.ai-gist-mobile {
 body.ai-gist-mobile {
   overscroll-behavior-y: none;
   -webkit-font-smoothing: antialiased;
+  font-size: var(--mobile-font-size-body);
 }
 
 html.ai-gist-mobile ion-content {
@@ -28,10 +64,6 @@ html.ai-gist-mobile ion-toolbar {
   --background: var(--surface-primary);
   --border-color: var(--border-default);
   --min-height: 52px;
-}
-
-html.ai-gist-mobile ion-title {
-  font-weight: 650;
 }
 
 html.ai-gist-mobile ion-item {
@@ -49,20 +81,220 @@ html.ai-gist-mobile ion-card {
   border: 1px solid var(--border-default);
 }
 
+/* ------------------------------------------------------------------ *
+ * 统一排版
+ * ------------------------------------------------------------------ */
+
+html.ai-gist-mobile ion-title {
+  font-size: var(--mobile-font-size-title);
+  font-weight: 600;
+}
+
+html.ai-gist-mobile ion-title.title-large {
+  font-size: var(--mobile-font-size-display);
+  font-weight: 700;
+}
+
+html.ai-gist-mobile ion-list-header {
+  min-height: 34px;
+  align-items: flex-end;
+  font-size: var(--mobile-font-size-footnote);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--content-secondary);
+}
+
+html.ai-gist-mobile ion-list-header ion-label {
+  margin-top: 16px;
+  margin-bottom: 6px;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+html.ai-gist-mobile ion-item,
+html.ai-gist-mobile ion-label,
+html.ai-gist-mobile ion-input,
+html.ai-gist-mobile ion-textarea,
+html.ai-gist-mobile ion-select,
+html.ai-gist-mobile ion-card-content,
+html.ai-gist-mobile ion-item-option {
+  font-size: var(--mobile-font-size-body);
+}
+
+html.ai-gist-mobile ion-label.ion-text-wrap {
+  font-size: var(--mobile-font-size-body);
+  line-height: var(--mobile-line-height-normal);
+}
+
+html.ai-gist-mobile ion-label h1 {
+  font-size: var(--mobile-font-size-title);
+  font-weight: 600;
+  line-height: var(--mobile-line-height-tight);
+}
+
+html.ai-gist-mobile ion-label h2,
+html.ai-gist-mobile ion-label h3,
+html.ai-gist-mobile ion-label h4,
+html.ai-gist-mobile ion-label h5,
+html.ai-gist-mobile ion-label h6 {
+  font-size: var(--mobile-font-size-body);
+  font-weight: 600;
+  line-height: var(--mobile-line-height-normal);
+}
+
+html.ai-gist-mobile ion-label p {
+  font-size: var(--mobile-font-size-footnote);
+  line-height: var(--mobile-line-height-normal);
+}
+
+html.ai-gist-mobile ion-note {
+  font-size: var(--mobile-font-size-footnote);
+}
+
+html.ai-gist-mobile ion-badge {
+  font-size: var(--mobile-font-size-caption);
+  font-weight: 600;
+}
+
+html.ai-gist-mobile ion-chip {
+  height: 26px;
+  padding-inline: 10px;
+  font-size: var(--mobile-font-size-footnote);
+}
+
+html.ai-gist-mobile ion-chip[size="small"] {
+  height: 22px;
+  padding-inline: 8px;
+  font-size: var(--mobile-font-size-caption);
+}
+
+html.ai-gist-mobile ion-chip ion-label {
+  font-size: inherit;
+}
+
+html.ai-gist-mobile ion-chip ion-icon {
+  font-size: 1.15em;
+}
+
+html.ai-gist-mobile ion-button {
+  font-size: var(--mobile-font-size-body);
+  font-weight: 500;
+}
+
+html.ai-gist-mobile ion-button[size="small"] {
+  font-size: var(--mobile-font-size-footnote);
+}
+
+html.ai-gist-mobile ion-item > ion-icon[slot="start"],
+html.ai-gist-mobile ion-item > ion-icon[slot="end"] {
+  font-size: var(--mobile-icon-size);
+}
+
+html.ai-gist-mobile ion-searchbar .searchbar-input {
+  font-size: var(--mobile-font-size-body);
+}
+
+/*
+ * 空状态是多个移动端页面共用的结构（.empty-container / .empty-state），
+ * 字号集中在这里定义，页面里的 scoped 样式只负责布局，避免各页面各写一套字号。
+ */
+html.ai-gist-mobile .empty-icon,
+html.ai-gist-mobile .empty-state > ion-icon {
+  font-size: var(--mobile-empty-icon-size);
+}
+
+html.ai-gist-mobile .empty-text,
+html.ai-gist-mobile .empty-state > p {
+  font-size: var(--mobile-font-size-title);
+  font-weight: 600;
+}
+
+html.ai-gist-mobile .empty-description {
+  font-size: var(--mobile-font-size-footnote);
+  line-height: var(--mobile-line-height-normal);
+}
+
+/* 页面内的区块标题（非 ion-* 组件） */
+html.ai-gist-mobile .section-title {
+  font-size: var(--mobile-font-size-title);
+  font-weight: 600;
+}
+
+/* ------------------------------------------------------------------ *
+ * 分段控件（列表 / 网格切换）
+ * Ionic iOS 模式给 ion-segment-button 设了 min-width: 70px 与 line-height: 37px，
+ * 在窄的纯图标分段控件里会撑破 ion-segment 的 grid 轨道（overflow: hidden），
+ * 导致图标看上去偏移、不居中。这里统一解除这两条约束。
+ * ------------------------------------------------------------------ */
+
+html.ai-gist-mobile ion-segment-button {
+  --padding-top: 0;
+  --padding-bottom: 0;
+  min-width: 0;
+  font-size: var(--mobile-font-size-footnote);
+  line-height: 1;
+}
+
+html.ai-gist-mobile ion-segment-button ion-icon {
+  font-size: var(--mobile-icon-size);
+}
+
+html.ai-gist-mobile ion-segment-button ion-label {
+  line-height: 1.2;
+  font-size: inherit;
+}
+
+/* ------------------------------------------------------------------ *
+ * 底部标签栏
+ * ------------------------------------------------------------------ */
+
 html.ai-gist-mobile ion-tab-bar {
   --background: var(--surface-primary);
   border-top-color: var(--border-default);
-  min-height: calc(var(--mobile-tabbar-height) + env(safe-area-inset-bottom, 0px));
-  padding-bottom: env(safe-area-inset-bottom, 0px);
+  /* content-box：这里的 height 只是内容高度，安全区由 padding-bottom 单独补 */
+  height: var(--mobile-tabbar-content-height);
+  min-height: 0;
+  padding-bottom: var(--mobile-tabbar-safe-inset);
 }
 
 html.ai-gist-mobile ion-tab-button {
-  min-height: var(--mobile-tabbar-height);
+  --padding-top: 2px;
+  --padding-bottom: 2px;
+  min-height: 0;
+  height: 100%;
 }
+
+html.ai-gist-mobile ion-tab-button ion-icon {
+  margin-top: 0;
+  margin-bottom: 1px;
+  font-size: 22px;
+}
+
+html.ai-gist-mobile ion-tab-button ion-label {
+  margin-top: 0;
+  margin-bottom: 0;
+  min-height: 0;
+  font-size: var(--mobile-font-size-caption);
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+/* ------------------------------------------------------------------ *
+ * 悬浮操作按钮
+ * ------------------------------------------------------------------ */
 
 html.ai-gist-mobile ion-fab[vertical="bottom"][horizontal="end"] {
   right: var(--mobile-page-gutter);
-  bottom: calc(env(safe-area-inset-bottom, 0px) + var(--mobile-tabbar-height) + 12px);
+  bottom: calc(env(safe-area-inset-bottom, 0px) + var(--mobile-fab-offset));
+}
+
+/*
+ * Tab 页面的内容区已经位于标签栏之上（ion-tabs 用 flex 把 router-outlet 排在标签栏前面），
+ * 标签栏本身覆盖了安全区，所以这里不需要再叠加 env(safe-area-inset-bottom)。
+ */
+html.ai-gist-mobile ion-tabs ion-fab[vertical="bottom"][horizontal="end"] {
+  bottom: var(--mobile-fab-offset);
 }
 
 html.ai-gist-mobile ion-fab-button {

--- a/src/renderer/components/mobile/MobileWaterfallView.vue
+++ b/src/renderer/components/mobile/MobileWaterfallView.vue
@@ -220,26 +220,26 @@ onUnmounted(() => {
 }
 
 .card-title {
-  font-size: 13px;
-  font-weight: 500;
+  font-size: var(--mobile-font-size-body);
+  font-weight: 600;
   color: var(--content-primary);
   margin: 0 0 4px;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  line-height: 1.4;
+  line-height: var(--mobile-line-height-normal);
 }
 
 .card-desc {
-  font-size: 12px;
+  font-size: var(--mobile-font-size-footnote);
   color: var(--content-secondary);
   margin: 0 0 6px;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  line-height: 1.3;
+  line-height: var(--mobile-line-height-normal);
 }
 
 .card-tags {
@@ -250,7 +250,7 @@ onUnmounted(() => {
 }
 
 .card-tag {
-  font-size: 10px;
+  font-size: var(--mobile-font-size-caption);
   padding: 2px 6px;
   border-radius: 10px;
   background: var(--surface-secondary);
@@ -266,7 +266,7 @@ onUnmounted(() => {
 }
 
 .card-category {
-  font-size: 11px;
+  font-size: var(--mobile-font-size-caption);
   color: var(--ion-color-primary, #3880ff);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -275,7 +275,7 @@ onUnmounted(() => {
 }
 
 .card-favorite {
-  font-size: 14px;
+  font-size: var(--mobile-icon-size-sm);
   color: var(--ion-color-danger, #eb445a);
   flex-shrink: 0;
 }

--- a/src/renderer/pages/mobile/MobileAIConfigDetailPage.vue
+++ b/src/renderer/pages/mobile/MobileAIConfigDetailPage.vue
@@ -519,8 +519,6 @@ onIonViewWillEnter(() => {
 }
 
 .section-title {
-  font-size: 16px;
-  font-weight: 600;
   color: var(--ion-text-color);
   margin-bottom: 12px;
   padding: 0 4px;
@@ -561,7 +559,7 @@ ion-item {
 .url-text {
   word-break: break-all;
   font-family: monospace;
-  font-size: 12px;
+  font-size: var(--mobile-font-size-footnote);
 }
 
 .masked-text {
@@ -582,8 +580,8 @@ ion-chip {
 .system-prompt-content {
   white-space: pre-wrap;
   font-family: monospace;
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: var(--mobile-font-size-footnote);
+  line-height: var(--mobile-line-height-normal);
   color: var(--ion-text-color);
   padding: 16px;
   max-height: 200px;

--- a/src/renderer/pages/mobile/MobileAIConfigEditPage.vue
+++ b/src/renderer/pages/mobile/MobileAIConfigEditPage.vue
@@ -584,8 +584,6 @@ onMounted(() => {
 }
 
 .section-title {
-  font-size: 16px;
-  font-weight: 600;
   color: var(--ion-text-color);
   margin-bottom: 12px;
   padding: 0 4px;
@@ -617,9 +615,9 @@ ion-item {
 
 .service-description {
   color: var(--ion-color-medium);
-  font-size: 14px;
+  font-size: var(--mobile-font-size-footnote);
   margin: 0 0 8px 0;
-  line-height: 1.5;
+  line-height: var(--mobile-line-height-normal);
 }
 
 .service-links {
@@ -669,7 +667,7 @@ ion-item {
 }
 
 .test-result-detail {
-  font-size: 13px;
+  font-size: var(--mobile-font-size-footnote);
   opacity: 0.8;
   word-break: break-word;
 }

--- a/src/renderer/pages/mobile/MobileAIConfigPage.vue
+++ b/src/renderer/pages/mobile/MobileAIConfigPage.vue
@@ -384,7 +384,6 @@ onUnmounted(() => {
 }
 
 .empty-icon {
-  font-size: 80px;
   color: var(--ion-color-medium);
   margin-bottom: 16px;
 }
@@ -392,12 +391,11 @@ onUnmounted(() => {
 .empty-text {
   color: var(--ion-color-medium);
   margin-bottom: 24px;
-  font-size: 16px;
 }
 
 .config-description {
   color: var(--ion-color-medium);
-  font-size: 14px;
+  font-size: var(--mobile-font-size-footnote);
   margin-top: 4px;
 }
 
@@ -432,7 +430,8 @@ ion-card {
 }
 
 ion-content {
-  --padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 104px);
+  /* 让列表底部留出悬浮按钮的空间；标签栏本身已经覆盖了安全区 */
+  --padding-bottom: var(--mobile-fab-clearance);
 }
 
 .preferred-alert {
@@ -450,12 +449,12 @@ ion-content {
 }
 
 .preferred-info ion-icon {
-  font-size: 24px;
+  font-size: var(--mobile-icon-size-lg);
 }
 
 .preferred-info p {
   margin: 4px 0 0 0;
-  font-size: 14px;
+  font-size: var(--mobile-font-size-footnote);
   opacity: 0.9;
 }
 
@@ -466,13 +465,13 @@ ion-content {
 }
 
 .warning-alert ion-icon {
-  font-size: 24px;
+  font-size: var(--mobile-icon-size-lg);
   flex-shrink: 0;
 }
 
 .warning-alert p {
   margin: 0;
-  font-size: 14px;
-  line-height: 1.5;
+  font-size: var(--mobile-font-size-footnote);
+  line-height: var(--mobile-line-height-normal);
 }
 </style>

--- a/src/renderer/pages/mobile/MobileAIGeneratorPage.vue
+++ b/src/renderer/pages/mobile/MobileAIGeneratorPage.vue
@@ -456,7 +456,6 @@ watch(() => route.path, (newPath) => {
 }
 
 .empty-icon {
-  font-size: 80px;
   color: var(--ion-color-medium);
   margin-bottom: 16px;
 }
@@ -464,14 +463,11 @@ watch(() => route.path, (newPath) => {
 .empty-text {
   color: var(--ion-color-dark);
   margin-bottom: 8px;
-  font-size: 18px;
-  font-weight: 600;
 }
 
 .empty-description {
   color: var(--ion-color-medium);
   margin-bottom: 24px;
-  font-size: 14px;
 }
 
 .generating-overlay {
@@ -489,7 +485,7 @@ watch(() => route.path, (newPath) => {
 .generating-overlay p {
   margin: 0;
   color: var(--ion-color-medium);
-  font-size: 14px;
+  font-size: var(--mobile-font-size-footnote);
 }
 
 ion-textarea {

--- a/src/renderer/pages/mobile/MobileAboutPage.vue
+++ b/src/renderer/pages/mobile/MobileAboutPage.vue
@@ -238,19 +238,19 @@ onMounted(async () => {
 }
 
 .app-info h2 {
-  font-size: 22px;
+  font-size: var(--mobile-font-size-display);
   font-weight: 700;
   margin: 0 0 6px;
 }
 
 .app-desc {
-  font-size: 14px;
+  font-size: var(--mobile-font-size-body);
   color: var(--ion-color-medium);
   margin: 0 0 4px;
 }
 
 .app-features {
-  font-size: 12px;
+  font-size: var(--mobile-font-size-footnote);
   color: var(--ion-color-medium);
   margin: 0;
 }
@@ -262,7 +262,7 @@ onMounted(async () => {
 }
 
 .version-badge {
-  font-size: 11px;
+  font-size: var(--mobile-font-size-caption);
 }
 
 .update-notice {
@@ -285,8 +285,8 @@ onMounted(async () => {
   padding: 12px;
   background: var(--surface-secondary);
   border-radius: 8px;
-  font-size: 13px;
-  line-height: 1.6;
+  font-size: var(--mobile-font-size-footnote);
+  line-height: var(--mobile-line-height-relaxed);
   white-space: pre-wrap;
   color: var(--content-primary);
 }

--- a/src/renderer/pages/mobile/MobileCloudBackupPage.vue
+++ b/src/renderer/pages/mobile/MobileCloudBackupPage.vue
@@ -1016,7 +1016,7 @@ onUnmounted(() => unsubscribeSyncStatus?.())
 
 .empty-state ion-icon {
   margin-bottom: 16px;
-  font-size: 64px;
+  font-size: var(--mobile-empty-icon-size);
 }
 
 .action-buttons {
@@ -1047,8 +1047,8 @@ onUnmounted(() => unsubscribeSyncStatus?.())
   padding: 10px;
   overflow: auto;
   color: var(--content-primary);
-  font-size: 12px;
-  line-height: 1.45;
+  font-size: var(--mobile-font-size-footnote);
+  line-height: var(--mobile-line-height-normal);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   background: var(--surface-secondary);

--- a/src/renderer/pages/mobile/MobilePromptDetailPage.vue
+++ b/src/renderer/pages/mobile/MobilePromptDetailPage.vue
@@ -376,14 +376,12 @@ onUnmounted(() => {
 }
 
 .empty-icon {
-  font-size: 80px;
   color: var(--ion-color-medium);
   margin-bottom: 16px;
 }
 
 .empty-text {
   color: var(--ion-color-medium);
-  font-size: 16px;
 }
 
 .prompt-header {
@@ -392,17 +390,17 @@ onUnmounted(() => {
 }
 
 .prompt-title {
-  font-size: 24px;
+  font-size: var(--mobile-font-size-heading);
   font-weight: 600;
   margin: 0 0 8px 0;
   color: var(--ion-text-color);
 }
 
 .prompt-description {
-  font-size: 14px;
+  font-size: var(--mobile-font-size-footnote);
   color: var(--ion-color-medium);
   margin: 0;
-  line-height: 1.5;
+  line-height: var(--mobile-line-height-normal);
 }
 
 .prompt-meta-row {
@@ -418,7 +416,7 @@ onUnmounted(() => {
   gap: 10px;
   margin-top: 10px;
   color: var(--ion-color-medium);
-  font-size: 12px;
+  font-size: var(--mobile-font-size-footnote);
 }
 
 .tags-container {
@@ -437,7 +435,7 @@ onUnmounted(() => {
 }
 
 .section-header h2 {
-  font-size: 18px;
+  font-size: var(--mobile-font-size-title);
   font-weight: 600;
   margin: 0;
   color: var(--ion-text-color);
@@ -452,8 +450,8 @@ onUnmounted(() => {
 
 .prompt-content {
   font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
-  font-size: 14px;
-  line-height: 1.6;
+  font-size: var(--mobile-font-size-body);
+  line-height: var(--mobile-line-height-relaxed);
   white-space: pre-wrap;
   word-wrap: break-word;
   color: var(--ion-text-color);

--- a/src/renderer/pages/mobile/MobilePromptPage.vue
+++ b/src/renderer/pages/mobile/MobilePromptPage.vue
@@ -637,17 +637,26 @@ onUnmounted(() => {
   min-height: 44px;
   padding: 8px 16px;
   color: var(--ion-color-medium);
-  font-size: 13px;
+  font-size: var(--mobile-font-size-footnote);
   border-bottom: 1px solid var(--border-default);
 }
 
 .view-mode-segment {
-  width: 112px;
-  min-width: 112px;
+  flex: 0 0 auto;
+  width: 84px;
+  min-width: 84px;
 }
 
+/*
+ * 纯图标分段控件：解除 Ionic iOS 模式的 min-width / line-height 约束，
+ * 否则轨道被撑破（ion-segment 是 overflow: hidden 的 grid），图标会偏移。
+ * 通用部分见 assets/styles/mobile.css。
+ */
 .view-mode-segment ion-segment-button {
-  min-height: 32px;
+  --padding-start: 0;
+  --padding-end: 0;
+  min-width: 0;
+  min-height: 30px;
 }
 
 .loading-container {
@@ -667,7 +676,6 @@ onUnmounted(() => {
 }
 
 .empty-icon {
-  font-size: 80px;
   color: var(--ion-color-medium);
   margin-bottom: 16px;
 }
@@ -675,12 +683,11 @@ onUnmounted(() => {
 .empty-text {
   color: var(--ion-color-medium);
   margin-bottom: 24px;
-  font-size: 16px;
 }
 
 .prompt-description {
   color: var(--ion-color-medium);
-  font-size: 14px;
+  font-size: var(--mobile-font-size-footnote);
   margin-top: 4px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -701,6 +708,7 @@ ion-chip {
 }
 
 ion-content {
-  --padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 104px);
+  /* 让列表底部留出悬浮按钮的空间；标签栏本身已经覆盖了安全区 */
+  --padding-bottom: var(--mobile-fab-clearance);
 }
 </style>

--- a/src/renderer/pages/mobile/MobileSettingsPage.vue
+++ b/src/renderer/pages/mobile/MobileSettingsPage.vue
@@ -562,13 +562,7 @@ onUnmounted(() => unsubscribeAutoBackupStatus?.())
 </script>
 
 <style scoped>
-ion-list-header {
-  font-weight: 600;
-  font-size: 14px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
+/* ion-list-header 的统一样式见 assets/styles/mobile.css */
 .backup-number-input {
   width: 88px;
   text-align: right;

--- a/src/renderer/pages/mobile/MobileSystemPromptEditPage.vue
+++ b/src/renderer/pages/mobile/MobileSystemPromptEditPage.vue
@@ -182,15 +182,15 @@ ion-card {
 
 .info-text {
   color: var(--ion-color-medium);
-  font-size: 14px;
-  line-height: 1.5;
+  font-size: var(--mobile-font-size-footnote);
+  line-height: var(--mobile-line-height-normal);
   margin: 0;
 }
 
 .system-prompt-textarea {
   font-family: monospace;
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: var(--mobile-font-size-body);
+  line-height: var(--mobile-line-height-normal);
   min-height: 400px;
 }
 


### PR DESCRIPTION
## 背景

移动端反馈三个问题：底部标签栏过高、各页面字号不统一、列表/网格切换按钮的图标不居中。

## 改动

### 1. 底部标签栏高度：124pt → 70pt（-43%）

这不只是数值偏大，而是一个实际的盒模型缺陷。`ion-tab-bar` 是 `box-sizing: content-box`，且 Ionic 自身已经把安全区作为 `padding-bottom` 加了一次。原规则是：

```css
min-height: calc(var(--mobile-tabbar-height) + env(safe-area-inset-bottom));  /* 56 + 34 = 90pt */
padding-bottom: env(safe-area-inset-bottom);                                  /* 又加 34pt */
```

34pt 的 home indicator 安全区被**重复计算**，总高 124pt。现改为内容盒固定 46pt，安全区只由 padding 承担一次并收窄 10pt（保底 6pt）。

同一处重复计算还导致两个衍生偏移过大，一并修正：

- FAB 原本悬在页面底部上方 102pt。`ion-tabs` 内的页面本身就结束于标签栏之上，无需再叠加安全区；非 Tab 页面（云备份）仍保留安全区偏移。
- 两个 Tab 页面的内容底部留白原为 138pt，现为 88pt，正好等于 FAB 的避让高度。

### 2. 统一字号

在 `mobile.css` 中新增 6 档字号阶梯（11 / 13 / 15 / 17 / 20 / 24px），并覆盖此前各自带默认值的 Ionic 组件（`ion-title`、`ion-label` h1–h6/p、`ion-note`、`ion-chip`、`ion-button`、`ion-list-header`、searchbar 输入框、各输入控件）。11 个移动端页面里所有硬编码 px 字号全部替换为 token；空状态、区块标题等跨页面复用结构的字号收敛到 `mobile.css` 单点维护，不再各页面各写一套。

`ion-list-header` 此前最不一致：设置页把它写成 14px 大写，其余页面则沿用 Ionic 默认的 22px 粗体。现已统一。

### 3. 列表/网格切换按钮图标居中

Ionic iOS 模式的 `ion-segment-button` 带有 `min-width: 70px` 与 `line-height: 37px`。两个这样的按钮放进 112px 宽的 `ion-segment` 时，会把 grid 轨道撑到 140px，而容器是 `overflow: hidden`，于是第二个按钮被裁切、两个图标都偏离中心。解除这两条约束并去掉 13px 的左右内边距即可。

## 验证

在 iPhone 17 Pro 模拟器（iOS 26.3，874pt 屏高、34pt 安全区）上构建安装运行。

- **标签栏高度**：对两次构建的截图做逐像素扫描定位标签栏上边框，得到修复前 **124.33pt**、修复后 **70.33pt**。为了拿到真实的对照值，我临时只回退了 `mobile.css` 重新构建取了一次「修复前」截图。这两个数字是量出来的，不是算出来的。
- **字号一致性**：遍历全部 11 个已挂载页面，收集每个含文本元素的 computed `font-size`，结果只出现 11/13/15/17/20/24 六个值，**0 个脱离阶梯**。
- **图标居中**：图标中心相对按钮中心的偏移为 **纵向 0px、横向 0.5px**（这 0.5px 来自 Ionic 自带的 1px 分段分隔线，无法消除且不可见）。
- `eslint` 对改动文件通过。

## Reviewer 需要知道的

- **本分支内容已经合并进 `dev` 并推送**（`b490fca`）。这个 PR 是把同一份改动直接提交到 `main` 的平行路径，而不是新的改动。如果你打算走常规的 `dev` → `main` 晋级流程，可以直接关掉这个 PR。
- 因为本分支从 `main` 当前 tip 分出，合并进 `dev` 时顺带把 `main` 最后两个提交带进了 `dev`（正常的 main→dev 同步方向）。本 PR 相对 `main` 只有 1 个提交，不含那次同步。
- 空状态插图字号从 80px/64px 统一到 56px，属于字号统一的一部分，是有意的视觉变化。
- 部分共享结构（`.empty-text`、`.empty-icon`、`.section-title`）的字号现在由 `mobile.css` 的全局规则提供，页面 scoped 样式只负责布局。这是刻意的单点维护，改这些类的字号请改 `mobile.css`。
- 交互截图（列表/网格切换）取自同一份代码在移动端浏览器壳下强制 `ionic:mode=ios` 的运行结果——模拟器缺少可交互面板，我无法在其中点击。标签栏、排版、空状态的验证均来自模拟器本身。
